### PR TITLE
Introduced testing DSL

### DIFF
--- a/test/ContosoUniversityCore.IntegrationTests/AutoMapperTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/AutoMapperTests.cs
@@ -4,7 +4,7 @@
 
     public class AutoMapperTests
     {
-        public void Should_have_valid_configuration(SliceFixture fixture) 
+        public void Should_have_valid_configuration() 
         {
             Mapper.AssertConfigurationIsValid();
         }

--- a/test/ContosoUniversityCore.IntegrationTests/DeleteData.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/DeleteData.cs
@@ -2,18 +2,19 @@
 {
     using System;
     using Fixie;
+    using static SliceFixture;
 
     public class DeleteData : FixtureBehavior, ClassBehavior
     {
         public void Execute(Class context, Action next)
         {
-            SliceFixture.ResetCheckpoint();
+            ResetCheckpoint();
             next();
         }
 
         public void Execute(Fixture context, Action next)
         {
-            SliceFixture.ResetCheckpoint();
+            ResetCheckpoint();
             next();
         }
     }

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Course/CreateTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Course/CreateTests.cs
@@ -7,18 +7,19 @@
     using ContosoUniversityCore.Features.Course;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class CreateTests
     {
-        public async Task Should_create_new_course(SliceFixture fixture)
+        public async Task Should_create_new_course()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var dept = new Department
             {
@@ -28,7 +29,7 @@
                 StartDate = DateTime.Today
             };
 
-            await fixture.InsertAsync(dept);
+            await InsertAsync(dept);
 
             var command = new Create.Command
             {
@@ -37,9 +38,9 @@
                 Number = 1234,
                 Title = "English 101"
             };
-            await fixture.SendAsync(command);
+            await SendAsync(command);
 
-            var created = await fixture.ExecuteDbContextAsync(db => db.Courses.Where(c => c.Id == command.Number).SingleOrDefaultAsync());
+            var created = await ExecuteDbContextAsync(db => db.Courses.Where(c => c.Id == command.Number).SingleOrDefaultAsync());
 
             created.ShouldNotBeNull();
             created.DepartmentID.ShouldBe(dept.Id);

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Course/DeleteTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Course/DeleteTests.cs
@@ -7,18 +7,19 @@
     using ContosoUniversityCore.Features.Course;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class DeleteTests
     {
-        public async Task Should_query_for_command(SliceFixture fixture)
+        public async Task Should_query_for_command()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var dept = new Department
             {
@@ -36,9 +37,9 @@
                 Title = "English 101"
             };
 
-            await fixture.InsertAsync(dept, course);
+            await InsertAsync(dept, course);
 
-            var result = await fixture.SendAsync(new Delete.Query {Id = course.Id});
+            var result = await SendAsync(new Delete.Query {Id = course.Id});
 
             result.ShouldNotBeNull();
             result.Credits.ShouldBe(course.Credits);
@@ -46,15 +47,15 @@
             result.Title.ShouldBe(course.Title);
         }
 
-        public async Task Should_delete(SliceFixture fixture)
+        public async Task Should_delete()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var dept = new Department
             {
@@ -72,11 +73,11 @@
                 Title = "English 101"
             };
 
-            await fixture.InsertAsync(dept, course);
+            await InsertAsync(dept, course);
 
-            await fixture.SendAsync(new Delete.Command {Id = course.Id});
+            await SendAsync(new Delete.Command {Id = course.Id});
 
-            var result = await fixture.ExecuteDbContextAsync(db => db.Courses.Where(c => c.Id == course.Id).SingleOrDefaultAsync());
+            var result = await ExecuteDbContextAsync(db => db.Courses.Where(c => c.Id == course.Id).SingleOrDefaultAsync());
 
             result.ShouldBeNull();
         }

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Course/DetailsTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Course/DetailsTests.cs
@@ -5,18 +5,19 @@
     using ContosoUniversityCore.Features.Course;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class DetailsTests
     {
-        public async Task Should_query_for_details(SliceFixture fixture)
+        public async Task Should_query_for_details()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var dept = new Department
             {
@@ -34,9 +35,9 @@
                 Title = "English 101"
             };
 
-            await fixture.InsertAsync(dept, course);
+            await InsertAsync(dept, course);
 
-            var result = await fixture.SendAsync(new Details.Query { Id = course.Id });
+            var result = await SendAsync(new Details.Query { Id = course.Id });
 
             result.ShouldNotBeNull();
             result.Credits.ShouldBe(course.Credits);

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Course/EditTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Course/EditTests.cs
@@ -7,18 +7,19 @@
     using Shouldly;
     using System.Linq;
     using System.Data.Entity;
+    using static SliceFixture;
 
     public class EditTests
     {
-        public async Task Should_query_for_command(SliceFixture fixture)
+        public async Task Should_query_for_command()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var dept = new Department
             {
@@ -35,9 +36,9 @@
                 Id = 1234,
                 Title = "English 101"
             };
-            await fixture.InsertAsync(dept, course);
+            await InsertAsync(dept, course);
 
-            var result = await fixture.SendAsync(new Edit.Query { Id = course.Id });
+            var result = await SendAsync(new Edit.Query { Id = course.Id });
 
             result.ShouldNotBeNull();
             result.Credits.ShouldBe(course.Credits);
@@ -45,15 +46,15 @@
             result.Title.ShouldBe(course.Title);
         }
 
-        public async Task Should_edit(SliceFixture fixture)
+        public async Task Should_edit()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var dept = new Department
             {
@@ -77,7 +78,7 @@
                 Id = 1234,
                 Title = "English 101"
             };
-            await fixture.InsertAsync(dept, newDept, course);
+            await InsertAsync(dept, newDept, course);
 
             var command = new Edit.Command
             {
@@ -86,9 +87,9 @@
                 Department = newDept,
                 Title = "English 202"
             };
-            await fixture.SendAsync(command);
+            await SendAsync(command);
 
-            var edited = await fixture.FindAsync<Course>(course.Id);
+            var edited = await FindAsync<Course>(course.Id);
 
             edited.ShouldNotBeNull();
             edited.DepartmentID.ShouldBe(newDept.Id);

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Course/IndexTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Course/IndexTests.cs
@@ -5,18 +5,19 @@
     using ContosoUniversityCore.Features.Course;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class IndexTests
     {
-        public async Task Should_return_all_courses(SliceFixture fixture)
+        public async Task Should_return_all_courses()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var englishDept = new Department
             {
@@ -47,23 +48,23 @@
                 Id = 4312,
                 Title = "History 101"
             };
-            await fixture.InsertAsync(englishDept, historyDept, english, history);
+            await InsertAsync(englishDept, historyDept, english, history);
 
-            var result = await fixture.SendAsync(new Index.Query());
+            var result = await SendAsync(new Index.Query());
 
             result.ShouldNotBeNull();
             result.Courses.Count.ShouldBe(2);
         }
 
-        public async Task Should_filter_courses(SliceFixture fixture)
+        public async Task Should_filter_courses()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var englishDept = new Department
             {
@@ -94,9 +95,9 @@
                 Id = 4312,
                 Title = "History 101"
             };
-            await fixture.InsertAsync(englishDept, historyDept, english, history);
+            await InsertAsync(englishDept, historyDept, english, history);
 
-            var result = await fixture.SendAsync(new Index.Query {SelectedDepartment = englishDept});
+            var result = await SendAsync(new Index.Query {SelectedDepartment = englishDept});
 
             result.ShouldNotBeNull();
             result.Courses.Count.ShouldBe(1);

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Department/CreateTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Department/CreateTests.cs
@@ -7,18 +7,19 @@
     using ContosoUniversityCore.Features.Department;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class CreateTests
     {
-        public async Task Should_create_new_department(SliceFixture fixture)
+        public async Task Should_create_new_department()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var command = new Create.Command
             {
@@ -28,9 +29,9 @@
                 Administrator = admin
             };
 
-            await fixture.SendAsync(command);
+            await SendAsync(command);
 
-            var created = await fixture.ExecuteDbContextAsync(db => db.Departments.Where(d => d.Name == command.Name).SingleOrDefaultAsync());
+            var created = await ExecuteDbContextAsync(db => db.Departments.Where(d => d.Name == command.Name).SingleOrDefaultAsync());
 
             created.ShouldNotBeNull();
             created.Budget.ShouldBe(command.Budget.GetValueOrDefault());

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Department/DeleteTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Department/DeleteTests.cs
@@ -6,18 +6,19 @@
     using ContosoUniversityCore.Features.Department;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class DeleteTests
     {
-        public async Task Should_delete_department(SliceFixture fixture)
+        public async Task Should_delete_department()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var dept = new Department
             {
@@ -26,7 +27,7 @@
                 Budget = 123m,
                 StartDate = DateTime.Today
             };
-            await fixture.InsertAsync(dept);
+            await InsertAsync(dept);
 
             var command = new Delete.Command
             {
@@ -34,9 +35,9 @@
                 RowVersion = dept.RowVersion
             };
 
-            await fixture.SendAsync(command);
+            await SendAsync(command);
 
-            var any = await fixture.ExecuteDbContextAsync(db => db.Departments.AnyAsync());
+            var any = await ExecuteDbContextAsync(db => db.Departments.AnyAsync());
 
             any.ShouldBeFalse();
         }

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Department/DetailsTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Department/DetailsTests.cs
@@ -6,18 +6,19 @@
     using ContosoUniversityCore.Features.Department;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class DetailsTests
     {
-        public async Task Should_get_department_details(SliceFixture fixture)
+        public async Task Should_get_department_details()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var dept = new Department
             {
@@ -26,14 +27,14 @@
                 Budget = 123m,
                 StartDate = DateTime.Today
             };
-            await fixture.InsertAsync(dept);
+            await InsertAsync(dept);
 
             var query = new Details.Query
             {
                 Id = dept.Id
             };
 
-            var result = await fixture.SendAsync(query);
+            var result = await SendAsync(query);
 
             result.ShouldNotBeNull();
             result.Name.ShouldBe(dept.Name);

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Department/EditTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Department/EditTests.cs
@@ -7,18 +7,19 @@
     using ContosoUniversityCore.Features.Department;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class EditTests
     {
-        public async Task Should_get_edit_department_details(SliceFixture fixture)
+        public async Task Should_get_edit_department_details()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var dept = new Department
             {
@@ -27,37 +28,37 @@
                 Budget = 123m,
                 StartDate = DateTime.Today
             };
-            await fixture.InsertAsync(dept);
+            await InsertAsync(dept);
 
             var query = new Edit.Query
             {
                 Id = dept.Id
             };
 
-            var result = await fixture.SendAsync(query);
+            var result = await SendAsync(query);
 
             result.ShouldNotBeNull();
             result.Name.ShouldBe(dept.Name);
             result.Administrator.Id.ShouldBe(admin.Id);
         }
 
-        public async Task Should_edit_department(SliceFixture fixture)
+        public async Task Should_edit_department()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
-            var admin2Id = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var admin2Id = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin2 = await fixture.FindAsync<Instructor>(admin2Id);
+            var admin2 = await FindAsync<Instructor>(admin2Id);
 
             var dept = new Department
             {
@@ -66,7 +67,7 @@
                 Budget = 123m,
                 StartDate = DateTime.Today
             };
-            await fixture.InsertAsync(dept);
+            await InsertAsync(dept);
 
             var command = new Edit.Command
             {
@@ -77,9 +78,9 @@
                 Budget = 456m
             };
 
-            await fixture.SendAsync(command);
+            await SendAsync(command);
 
-            var result = await fixture.ExecuteDbContextAsync(db => db.Departments.Where(d => d.Id == dept.Id).Include(d => d.Administrator).SingleOrDefaultAsync());
+            var result = await ExecuteDbContextAsync(db => db.Departments.Where(d => d.Id == dept.Id).Include(d => d.Administrator).SingleOrDefaultAsync());
 
             result.Name.ShouldBe(command.Name);
             result.Administrator.Id.ShouldBe(command.Administrator.Id);

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Department/IndexTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Department/IndexTests.cs
@@ -5,18 +5,19 @@
     using ContosoUniversityCore.Features.Department;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class IndexTests
     {
-        public async Task Should_list_departments(SliceFixture fixture)
+        public async Task Should_list_departments()
         {
-            var adminId = await fixture.SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
+            var adminId = await SendAsync(new ContosoUniversityCore.Features.Instructor.CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
                 HireDate = DateTime.Today,
             });
-            var admin = await fixture.FindAsync<Instructor>(adminId);
+            var admin = await FindAsync<Instructor>(adminId);
 
             var dept = new Department
             {
@@ -33,11 +34,11 @@
                 StartDate = DateTime.Today
             };
 
-            await fixture.InsertAsync(dept, dept2);
+            await InsertAsync(dept, dept2);
 
             var query = new Index.Query();
 
-            var result = await fixture.SendAsync(query);
+            var result = await SendAsync(query);
 
             result.ShouldNotBeNull();
             result.Count.ShouldBe(2);

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Instructor/CreateEditTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Instructor/CreateEditTests.cs
@@ -8,10 +8,11 @@
     using ContosoUniversityCore.Features.Instructor;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class CreateEditTests
     {
-        public async Task Should_create_new_instructor(SliceFixture fixture)
+        public async Task Should_create_new_instructor()
         {
             var englishDept = new Department
             {
@@ -33,7 +34,7 @@
                 Id = 456
             };
 
-            await fixture.InsertAsync(englishDept, english101, english201);
+            await InsertAsync(englishDept, english101, english201);
 
             var command = new CreateEdit.Command
             {
@@ -44,9 +45,9 @@
                 SelectedCourses = new [] {english101.Id.ToString(), english201.Id.ToString()}
             };
 
-            await fixture.SendAsync(command);
+            await SendAsync(command);
 
-            var created = await fixture.ExecuteDbContextAsync(db => db.Instructors.Include(i => i.CourseInstructors).Include(i => i.OfficeAssignment).SingleOrDefaultAsync());
+            var created = await ExecuteDbContextAsync(db => db.Instructors.Include(i => i.CourseInstructors).Include(i => i.OfficeAssignment).SingleOrDefaultAsync());
 
             created.FirstMidName.ShouldBe(command.FirstMidName);
             created.LastName.ShouldBe(command.LastName);
@@ -56,7 +57,7 @@
             created.CourseInstructors.Count.ShouldBe(2);
         }
 
-        public async Task Should_edit_instructor_details(SliceFixture fixture)
+        public async Task Should_edit_instructor_details()
         {
             var englishDept = new Department
             {
@@ -78,9 +79,9 @@
                 Id = 456
             };
 
-            await fixture.InsertAsync(englishDept, english101, english201);
+            await InsertAsync(englishDept, english101, english201);
 
-            var instructorId = await fixture.SendAsync(new CreateEdit.Command
+            var instructorId = await SendAsync(new CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
@@ -98,9 +99,9 @@
                 Id = instructorId
             };
 
-            await fixture.SendAsync(command);
+            await SendAsync(command);
 
-            var edited = await fixture.ExecuteDbContextAsync(db => db.Instructors.Where(i => i.Id == instructorId).Include(i => i.CourseInstructors).Include(i => i.OfficeAssignment).SingleOrDefaultAsync());
+            var edited = await ExecuteDbContextAsync(db => db.Instructors.Where(i => i.Id == instructorId).Include(i => i.CourseInstructors).Include(i => i.OfficeAssignment).SingleOrDefaultAsync());
 
             edited.FirstMidName.ShouldBe(command.FirstMidName);
             edited.LastName.ShouldBe(command.LastName);
@@ -109,7 +110,7 @@
             edited.OfficeAssignment.Location.ShouldBe(command.OfficeAssignmentLocation);
         }
 
-        public async Task Should_merge_course_instructors(SliceFixture fixture)
+        public async Task Should_merge_course_instructors()
         {
             var englishDept = new Department
             {
@@ -130,9 +131,9 @@
                 Credits = 4,
                 Id = 456
             };
-            await fixture.InsertAsync(englishDept, english101, english201);
+            await InsertAsync(englishDept, english101, english201);
 
-            var instructorId = await fixture.SendAsync(new CreateEdit.Command
+            var instructorId = await SendAsync(new CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
@@ -151,9 +152,9 @@
                 Id = instructorId
             };
 
-            await fixture.SendAsync(command);
+            await SendAsync(command);
 
-            var edited = await fixture.ExecuteDbContextAsync(db => db.Instructors.Where(i => i.Id == instructorId).Include(i => i.CourseInstructors).Include(i => i.OfficeAssignment).SingleOrDefaultAsync());
+            var edited = await ExecuteDbContextAsync(db => db.Instructors.Where(i => i.Id == instructorId).Include(i => i.CourseInstructors).Include(i => i.OfficeAssignment).SingleOrDefaultAsync());
 
             edited.FirstMidName.ShouldBe(command.FirstMidName);
             edited.LastName.ShouldBe(command.LastName);

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Instructor/DeleteTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Instructor/DeleteTests.cs
@@ -7,10 +7,11 @@
     using ContosoUniversityCore.Features.Instructor;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class DeleteTests
     {
-        public async Task Should_query_for_command(SliceFixture fixture)
+        public async Task Should_query_for_command()
         {
             var englishDept = new Department
             {
@@ -32,20 +33,20 @@
                 HireDate = DateTime.Today,
                 SelectedCourses = new []{ english101.Id.ToString()}
             };
-            var instructorId = await fixture.SendAsync(command);
+            var instructorId = await SendAsync(command);
 
-            await fixture.InsertAsync(englishDept, english101);
+            await InsertAsync(englishDept, english101);
 
-            var result = await fixture.SendAsync(new Delete.Query { Id = instructorId });
+            var result = await SendAsync(new Delete.Query { Id = instructorId });
 
             result.ShouldNotBeNull();
             result.FirstMidName.ShouldBe(command.FirstMidName);
             result.OfficeAssignmentLocation.ShouldBe(command.OfficeAssignmentLocation);
         }
 
-        public async Task Should_delete_instructor(SliceFixture fixture)
+        public async Task Should_delete_instructor()
         {
-            var instructorId = await fixture.SendAsync(new CreateEdit.Command
+            var instructorId = await SendAsync(new CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
@@ -66,9 +67,9 @@
                 Id = 123
             };
 
-            await fixture.InsertAsync(englishDept, english101);
+            await InsertAsync(englishDept, english101);
 
-            await fixture.SendAsync(new CreateEdit.Command
+            await SendAsync(new CreateEdit.Command
             {
                 Id = instructorId,
                 FirstMidName = "George",
@@ -78,18 +79,18 @@
                 SelectedCourses = new[] { english101.Id.ToString() }
             });
 
-            await fixture.SendAsync(new Delete.Command { ID = instructorId });
+            await SendAsync(new Delete.Command { ID = instructorId });
 
-            var instructorCount = await fixture.ExecuteDbContextAsync(db => db.Instructors.CountAsync());
+            var instructorCount = await ExecuteDbContextAsync(db => db.Instructors.CountAsync());
 
             instructorCount.ShouldBe(0);
 
             var englishDeptId = englishDept.Id;
-            englishDept = await fixture.ExecuteDbContextAsync(db => db.Departments.FindAsync(englishDeptId));
+            englishDept = await ExecuteDbContextAsync(db => db.Departments.FindAsync(englishDeptId));
 
             englishDept.InstructorID.ShouldBeNull();
 
-            var courseInstructorCount = await fixture.ExecuteDbContextAsync(db => db.CourseInstructors.CountAsync());
+            var courseInstructorCount = await ExecuteDbContextAsync(db => db.CourseInstructors.CountAsync());
 
             courseInstructorCount.ShouldBe(0);
         }

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Instructor/DetailsTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Instructor/DetailsTests.cs
@@ -6,10 +6,11 @@
     using ContosoUniversityCore.Features.Instructor;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class DetailsTests
     {
-        public async Task Should_get_instructor_details(SliceFixture fixture)
+        public async Task Should_get_instructor_details()
         {
             var englishDept = new Department
             {
@@ -23,7 +24,7 @@
                 Credits = 4,
                 Id = 123
             };
-            await fixture.InsertAsync(englishDept, english101);
+            await InsertAsync(englishDept, english101);
 
             var command = new CreateEdit.Command
             {
@@ -33,9 +34,9 @@
                 HireDate = DateTime.Today,
                 SelectedCourses = new[] { english101.Id.ToString() }
             };
-            var instructorId = await fixture.SendAsync(command);
+            var instructorId = await SendAsync(command);
 
-            var result = await fixture.SendAsync(new Details.Query { Id = instructorId });
+            var result = await SendAsync(new Details.Query { Id = instructorId });
 
             result.ShouldNotBeNull();
             result.FirstMidName.ShouldBe(command.FirstMidName);

--- a/test/ContosoUniversityCore.IntegrationTests/Features/Instructor/IndexTests.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/Features/Instructor/IndexTests.cs
@@ -6,10 +6,11 @@
     using ContosoUniversityCore.Features.Instructor;
     using Domain;
     using Shouldly;
+    using static SliceFixture;
 
     public class IndexTests
     {
-        public async Task Should_get_list_instructor_with_details(SliceFixture fixture)
+        public async Task Should_get_list_instructor_with_details()
         {
             var englishDept = new Department
             {
@@ -31,9 +32,9 @@
                 Id = 456
             };
 
-            await fixture.InsertAsync(englishDept, english101, english201);
+            await InsertAsync(englishDept, english101, english201);
 
-            var instructor1Id = await fixture.SendAsync(new CreateEdit.Command
+            var instructor1Id = await SendAsync(new CreateEdit.Command
             {
                 FirstMidName = "George",
                 LastName = "Costanza",
@@ -42,7 +43,7 @@
                 OfficeAssignmentLocation = "Austin",
             });
 
-            await fixture.SendAsync(new CreateEdit.Command
+            await SendAsync(new CreateEdit.Command
             {
                 OfficeAssignmentLocation = "Houston",
                 FirstMidName = "Jerry",
@@ -63,14 +64,14 @@
                 EnrollmentDate = DateTime.Today
             };
 
-            await fixture.InsertAsync(student1, student2);
+            await InsertAsync(student1, student2);
 
             var enrollment1 = new Enrollment { StudentID = student1.Id, CourseID = english101.Id };
             var enrollment2 = new Enrollment { StudentID = student2.Id, CourseID = english101.Id };
 
-            await fixture.InsertAsync(enrollment1, enrollment2);
+            await InsertAsync(enrollment1, enrollment2);
 
-            var result = await fixture.SendAsync(new Index.Query { Id = instructor1Id, CourseID = english101.Id });
+            var result = await SendAsync(new Index.Query { Id = instructor1Id, CourseID = english101.Id });
 
             result.ShouldNotBeNull();
 

--- a/test/ContosoUniversityCore.IntegrationTests/FixturePerClassConvention.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/FixturePerClassConvention.cs
@@ -13,13 +13,6 @@
             ClassExecution
                 .CreateInstancePerClass()
                 .Wrap<DeleteData>();
-
-            Parameters.Add(
-                mi =>
-                    (mi.GetParameters().Length == 1) &&
-                    (mi.GetParameters()[0].ParameterType == typeof(SliceFixture))
-                        ? new[] {new[] {new SliceFixture()}}
-                        : null);
         }
     }
 }

--- a/test/ContosoUniversityCore.IntegrationTests/FixturePerMethodConvention.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/FixturePerMethodConvention.cs
@@ -13,13 +13,6 @@
             ClassExecution
                 .CreateInstancePerCase();
 
-            Parameters.Add(
-                mi =>
-                    (mi.GetParameters().Length == 1) &&
-                    (mi.GetParameters()[0].ParameterType == typeof(SliceFixture))
-                        ? new[] {new[] {new SliceFixture()}}
-                        : null);
-
             FixtureExecution
                 .Wrap<DeleteData>();
         }

--- a/test/ContosoUniversityCore.IntegrationTests/SliceFixture.cs
+++ b/test/ContosoUniversityCore.IntegrationTests/SliceFixture.cs
@@ -56,7 +56,7 @@
             _checkpoint.Reset(_configuration["Data:DefaultConnection:ConnectionString"]);
         }
 
-        public async Task ExecuteScopeAsync(Func<IServiceProvider, Task> action)
+        public static async Task ExecuteScopeAsync(Func<IServiceProvider, Task> action)
         {
             using (var scope = _scopeFactory.CreateScope())
             {
@@ -78,7 +78,7 @@
             }
         }
 
-        public async Task<T> ExecuteScopeAsync<T>(Func<IServiceProvider, Task<T>> action)
+        public static async Task<T> ExecuteScopeAsync<T>(Func<IServiceProvider, Task<T>> action)
         {
             using (var scope = _scopeFactory.CreateScope())
             {
@@ -102,17 +102,17 @@
             }
         }
 
-        public Task ExecuteDbContextAsync(Func<SchoolContext, Task> action)
+        public static Task ExecuteDbContextAsync(Func<SchoolContext, Task> action)
         {
             return ExecuteScopeAsync(sp => action(sp.GetService<SchoolContext>()));
         }
 
-        public Task<T> ExecuteDbContextAsync<T>(Func<SchoolContext, Task<T>> action)
+        public static Task<T> ExecuteDbContextAsync<T>(Func<SchoolContext, Task<T>> action)
         {
             return ExecuteScopeAsync(sp => action(sp.GetService<SchoolContext>()));
         }
 
-        public Task InsertAsync(params IEntity[] entities)
+        public static Task InsertAsync(params IEntity[] entities)
         {
             return ExecuteDbContextAsync(db =>
             {
@@ -124,13 +124,13 @@
             });
         }
 
-        public Task<T> FindAsync<T>(int id)
+        public static Task<T> FindAsync<T>(int id)
             where T : class, IEntity
         {
             return ExecuteDbContextAsync(db => db.Set<T>().FindAsync(id));
         }
 
-        public Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request)
+        public static Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request)
         {
             return ExecuteScopeAsync(sp =>
             {
@@ -140,7 +140,7 @@
             });
         }
 
-        public Task SendAsync(IRequest request)
+        public static Task SendAsync(IRequest request)
         {
             return ExecuteScopeAsync(sp =>
             {


### PR DESCRIPTION
I've been looking what else we can do to improve this great repository. I've recently read your colleague's [post](https://lostechies.com/patricklioi/2016/01/27/powerful-integration-testing/) and it inspired me do some changes. I'll introduce them step by step to be sure you're on board with these ideas.

This time I introduced testing DSL using C# 6 "using static" feature instead of injecting SliceFixture parameter. Honestly this parameter was very confusing when I looked at the codebase for the first time. Like... what is it? Does it pregenerate some input data or what? Semantically it's not a parameter for our tests, it's just a piece of infrastructure. Hopefully, tests look a little bit clearer now. And by the way one more advantage of this approach is that SliceFixture becomes extensible (i. e. we can introduce PostsSliceFixture and import it specifically to Posts tests).

P. S. It looks like a lot of changes (a lot of find&replace actually) but basically I've done three things:
1. Made all SliceFixture methods static
2. Removed SliceFixture as a parameter in tests
3. Removed SliceFixture parameter configuration from Convention classes.