### PR TITLE
Connection string

### DIFF
--- a/src/ContosoUniversityCore/appsettings.json
+++ b/src/ContosoUniversityCore/appsettings.json
@@ -9,7 +9,7 @@
   },
   "Data": {
     "DefaultConnection": {
-      "ConnectionString": "Data Source=(LocalDb)\\v12.0;Initial Catalog=ContosoUniversity;Integrated Security=SSPI;"
+      "ConnectionString": "Data Source=(LocalDb)\\MSSQLLocalDB;Initial Catalog=ContosoUniversity;Integrated Security=SSPI;"
     }
   }
 }


### PR DESCRIPTION
Change connection string data source to MSSQLLocalDB. This is the new default name for the automatic instance since sql 2014.

The current connection string does not work on any new installed dev environment with SQL > 2012
